### PR TITLE
add missing 'fs' dependency to the examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ const result = excelToJson({
 ```javascript
 'use strict';
 const excelToJson = require('convert-excel-to-json');
+const fs = require('fs');
 
 const result = excelToJson({
 	source: fs.readFileSync('SOME-EXCEL-FILE.xlsx') // fs.readFileSync return a Buffer


### PR DESCRIPTION
because 'fs' was not required fs.readFileSync was throwing an error