### PR TITLE
update all deps to latest stable versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,15 @@
 {
   "name": "convert-excel-to-json",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
     "adler-32": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
@@ -13,18 +19,50 @@
         "printj": "~1.1.0"
       }
     },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
     "ansi-escape-sequences": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
-      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz",
+      "integrity": "sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==",
       "requires": {
-        "array-back": "^2.0.0"
+        "array-back": "^3.0.1"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+        }
       }
     },
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -49,9 +87,15 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
     "brace-expansion": {
@@ -62,6 +106,15 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
       }
     },
     "browser-stdout": {
@@ -76,44 +129,136 @@
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
     "cfb": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.0.8.tgz",
-      "integrity": "sha1-d/ITST1pfXVP2cD1UR6rWtctAs8=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.0.tgz",
+      "integrity": "sha512-sXMvHsKCICVR3Naq+J556K+ExBo9n50iKl6LGarlnvuA2035uMlGA/qVrc0wQtow5P1vJEw9UyrKLCbtIKz+TQ==",
       "requires": {
-        "commander": "^2.14.1",
+        "adler-32": "~1.2.0",
+        "crc-32": "~1.2.0",
         "printj": "~1.1.2"
       }
     },
     "chai": {
-      "version": "3.5.0",
-      "resolved": "http://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "chokidar": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
       }
     },
     "cliss": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/cliss/-/cliss-0.0.2.tgz",
-      "integrity": "sha512-6rj9pgdukjT994Md13JCUAgTk91abAKrygL9sAvmHY4F6AKMOV8ccGaxhUUfcBuyg3sundWnn3JE0Mc9W6ZYqw==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/cliss/-/cliss-0.0.8.tgz",
+      "integrity": "sha512-kQ5X6bzVdfTSnyvCeqSnOsWBFFL53XQAVwSht3NFD2eq6eFl6pZLphR0/W1kPVWoMEI7OSUiggfQP9I/4HEu6Q==",
       "requires": {
         "command-line-usage": "^4.0.1",
         "deepmerge": "^2.0.0",
         "get-stdin": "^5.0.1",
-        "inspect-parameters-declaration": "0.0.9",
-        "object-to-arguments": "0.0.8",
+        "inspect-parameters-declaration": "^0.1.0",
+        "object-to-arguments": "^0.1.0",
         "pipe-functions": "^1.3.0",
         "strip-ansi": "^4.0.0",
         "yargs-parser": "^7.0.0"
       }
     },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
     "codepage": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.13.1.tgz",
-      "integrity": "sha512-KnY6cQlgkfBjplnQkLk3M5KEfAKa7i9SMqXp+bMuy2/bgYovvU4LDAQvkMaoScwhvozA9VUtgnbS4Z8f7zVA8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.14.0.tgz",
+      "integrity": "sha1-jL4lSBMjVZ19MHVxsP/5HnodL5k=",
       "requires": {
         "commander": "~2.14.1",
         "exit-on-epipe": "~1.0.1"
@@ -121,10 +266,25 @@
       "dependencies": {
         "commander": {
           "version": "2.14.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
           "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
         }
       }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "command-line-usage": {
       "version": "4.1.0",
@@ -138,9 +298,9 @@
       }
     },
     "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -158,29 +318,35 @@
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
-      }
-    },
-    "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
-      "dev": true,
-      "requires": {
-        "type-detect": "0.1.1"
+        "ms": "2.1.2"
       },
       "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
+      }
+    },
+    "decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
       }
     },
     "deep-extend": {
@@ -194,21 +360,47 @@
       "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
     },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
     },
     "exit-on-epipe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
       "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
+    },
+    "fflate": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.3.11.tgz",
+      "integrity": "sha512-Rr5QlUeGN1mbOHlaqcSYMKVpPbgLy0AWT/W0EHxA6NGI12yO1jpoui2zBBvU2G824ltM6Ut8BFgfHSBGfkmS0A=="
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
     },
     "find-up": {
       "version": "2.1.0",
@@ -217,6 +409,12 @@
       "requires": {
         "locate-path": "^2.0.0"
       }
+    },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
     },
     "for-each-property": {
       "version": "0.0.4",
@@ -245,10 +443,29 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "get-prototype-chain": {
       "version": "1.0.1",
@@ -261,9 +478,9 @@
       "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -272,6 +489,15 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "growl": {
@@ -289,15 +515,15 @@
       }
     },
     "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "inflight": {
@@ -311,9 +537,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "inspect-function": {
@@ -333,48 +559,314 @@
       }
     },
     "inspect-parameters-declaration": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.9.tgz",
-      "integrity": "sha512-c3jrKKA1rwwrsjdGMAo2hFWV0vNe3/RKHxpE/OBt41LP3ynOVI1qmgxpZYK5SQu3jtWCyaho8L7AZzCjJ4mEUw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.1.0.tgz",
+      "integrity": "sha512-06xVJBwmGsVwA/Nap6Yfb2PFP+qJWibVzGRvYtA9DiEJqhZNlSB2uEoDGBlGinSiOOGGldozT5fMZD0ZhVJB1w==",
       "requires": {
-        "magicli": "0.0.5",
+        "magicli": "0.0.8",
         "split-skip": "0.0.2",
-        "stringify-parameters": "0.0.4",
+        "stringify-parameters": "0.0.7",
         "unpack-string": "0.0.2"
       },
       "dependencies": {
-        "magicli": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
-          "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+        "cliss": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/cliss/-/cliss-0.0.2.tgz",
+          "integrity": "sha512-6rj9pgdukjT994Md13JCUAgTk91abAKrygL9sAvmHY4F6AKMOV8ccGaxhUUfcBuyg3sundWnn3JE0Mc9W6ZYqw==",
           "requires": {
-            "commander": "^2.9.0",
+            "command-line-usage": "^4.0.1",
+            "deepmerge": "^2.0.0",
             "get-stdin": "^5.0.1",
-            "inspect-function": "^0.2.1",
-            "pipe-functions": "^1.2.0"
+            "object-to-arguments": "0.0.8",
+            "pipe-functions": "^1.3.0",
+            "strip-ansi": "^4.0.0",
+            "yargs-parser": "^7.0.0"
+          }
+        },
+        "inspect-parameters-declaration": {
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.9.tgz",
+          "integrity": "sha512-c3jrKKA1rwwrsjdGMAo2hFWV0vNe3/RKHxpE/OBt41LP3ynOVI1qmgxpZYK5SQu3jtWCyaho8L7AZzCjJ4mEUw==",
+          "requires": {
+            "magicli": "0.0.5",
+            "split-skip": "0.0.2",
+            "stringify-parameters": "0.0.4",
+            "unpack-string": "0.0.2"
+          },
+          "dependencies": {
+            "magicli": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+              "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+              "requires": {
+                "commander": "^2.9.0",
+                "get-stdin": "^5.0.1",
+                "inspect-function": "^0.2.1",
+                "pipe-functions": "^1.2.0"
+              }
+            },
+            "stringify-parameters": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",
+              "integrity": "sha512-H3L90ERn5UPtkpO8eugnKcLgpIVlvTyUTrcLGm607AV5JDH6z0GymtNLr3gjGlP6I6NB/mxNX9QpY6jEQGLPdQ==",
+              "requires": {
+                "magicli": "0.0.5",
+                "unpack-string": "0.0.2"
+              }
+            }
+          }
+        },
+        "inspect-property": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/inspect-property/-/inspect-property-0.0.6.tgz",
+          "integrity": "sha512-LgjHkRl9W6bj2n+kWrAOgvCYPTYt+LanE4rtd/vKNq6yEb+SvVV7UTLzoSPpDX6/U1cAz7VfqPr+lPAIz7wHaQ==",
+          "requires": {
+            "for-each-property": "0.0.4",
+            "for-each-property-deep": "0.0.3",
+            "inspect-function": "^0.3.1"
+          },
+          "dependencies": {
+            "inspect-function": {
+              "version": "0.3.4",
+              "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.3.4.tgz",
+              "integrity": "sha512-s0RsbJqK/sNZ+U1mykGoTickog3ea1A9Qk4mXniogOBu4PgkkZ56elScO7QC/r8D94lhGmJ2NyDI1ipOA/uq/g==",
+              "requires": {
+                "inspect-parameters-declaration": "0.0.8",
+                "magicli": "0.0.8",
+                "split-skip": "0.0.1",
+                "stringify-parameters": "0.0.4",
+                "unpack-string": "0.0.2"
+              }
+            },
+            "inspect-parameters-declaration": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.8.tgz",
+              "integrity": "sha512-W4QzN1LgFmasKOM+NoLlDd2OAZM3enNZlVUOXoGQKmYBDFgxoPDOyebF55ALaf8avyM9TavNwibXxg347RrzCg==",
+              "requires": {
+                "magicli": "0.0.5",
+                "split-skip": "0.0.2",
+                "stringify-parameters": "0.0.4",
+                "unpack-string": "0.0.2"
+              },
+              "dependencies": {
+                "inspect-function": {
+                  "version": "0.2.2",
+                  "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.2.2.tgz",
+                  "integrity": "sha1-hdoMUli8TDMK4yg7Z0fgdZ2QpjU=",
+                  "requires": {
+                    "split-skip": "0.0.1",
+                    "unpack-string": "0.0.2"
+                  },
+                  "dependencies": {
+                    "split-skip": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.1.tgz",
+                      "integrity": "sha1-gK2ONumOV2RUzDtmfB3SXYZejwA="
+                    }
+                  }
+                },
+                "magicli": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+                  "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+                  "requires": {
+                    "commander": "^2.9.0",
+                    "get-stdin": "^5.0.1",
+                    "inspect-function": "^0.2.1",
+                    "pipe-functions": "^1.2.0"
+                  }
+                },
+                "split-skip": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.2.tgz",
+                  "integrity": "sha1-2J2Iu9L3Pka1FYqjcKVhIk6A1GE="
+                }
+              }
+            },
+            "split-skip": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.1.tgz",
+              "integrity": "sha1-gK2ONumOV2RUzDtmfB3SXYZejwA="
+            },
+            "stringify-parameters": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",
+              "integrity": "sha512-H3L90ERn5UPtkpO8eugnKcLgpIVlvTyUTrcLGm607AV5JDH6z0GymtNLr3gjGlP6I6NB/mxNX9QpY6jEQGLPdQ==",
+              "requires": {
+                "magicli": "0.0.5",
+                "unpack-string": "0.0.2"
+              },
+              "dependencies": {
+                "inspect-function": {
+                  "version": "0.2.2",
+                  "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.2.2.tgz",
+                  "integrity": "sha1-hdoMUli8TDMK4yg7Z0fgdZ2QpjU=",
+                  "requires": {
+                    "split-skip": "0.0.1",
+                    "unpack-string": "0.0.2"
+                  }
+                },
+                "magicli": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+                  "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+                  "requires": {
+                    "commander": "^2.9.0",
+                    "get-stdin": "^5.0.1",
+                    "inspect-function": "^0.2.1",
+                    "pipe-functions": "^1.2.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "magicli": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.8.tgz",
+          "integrity": "sha512-x/eBenweAHF+DsYy172sK4doRxZl0yrJnfxhLJiN7H6hPM3Ya0PfI6uBZshZ3ScFFSQD7HXgBqMdbnXKEZsO1g==",
+          "requires": {
+            "cliss": "0.0.2",
+            "find-up": "^2.1.0",
+            "for-each-property": "0.0.4",
+            "inspect-property": "0.0.6"
+          }
+        },
+        "object-to-arguments": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/object-to-arguments/-/object-to-arguments-0.0.8.tgz",
+          "integrity": "sha512-BfWfuAwuhdH1bhMG5EG90WE/eckkBhBvnke8eSEkCDXoLE9Jk5JwYGTbCx1ehGwV48HvBkn62VukPBdlMUOY9w==",
+          "requires": {
+            "inspect-parameters-declaration": "0.0.10",
+            "magicli": "0.0.5",
+            "split-skip": "0.0.2",
+            "stringify-parameters": "0.0.4",
+            "unpack-string": "0.0.2"
+          },
+          "dependencies": {
+            "inspect-parameters-declaration": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.10.tgz",
+              "integrity": "sha512-L8/Bvt9iDXQTZ63xY5/MAyvzz+FagR/qGh1kIXvUpsno3AAE0Z95d6QO51zrcMGaEGpwh/57idfMxTxbvRmytg==",
+              "requires": {
+                "magicli": "0.0.5",
+                "split-skip": "0.0.2",
+                "stringify-parameters": "0.0.4",
+                "unpack-string": "0.0.2"
+              }
+            },
+            "magicli": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+              "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+              "requires": {
+                "commander": "^2.9.0",
+                "get-stdin": "^5.0.1",
+                "inspect-function": "^0.2.1",
+                "pipe-functions": "^1.2.0"
+              }
+            },
+            "stringify-parameters": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",
+              "integrity": "sha512-H3L90ERn5UPtkpO8eugnKcLgpIVlvTyUTrcLGm607AV5JDH6z0GymtNLr3gjGlP6I6NB/mxNX9QpY6jEQGLPdQ==",
+              "requires": {
+                "magicli": "0.0.5",
+                "unpack-string": "0.0.2"
+              }
+            }
           }
         }
       }
     },
     "inspect-property": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/inspect-property/-/inspect-property-0.0.6.tgz",
-      "integrity": "sha512-LgjHkRl9W6bj2n+kWrAOgvCYPTYt+LanE4rtd/vKNq6yEb+SvVV7UTLzoSPpDX6/U1cAz7VfqPr+lPAIz7wHaQ==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/inspect-property/-/inspect-property-0.0.7.tgz",
+      "integrity": "sha512-/4hl49odQNw3QSik9F8OsnG8Ms/OEGlZNMxK/wf9z0F1eGSgka4uZtY9DSh1w+iZJi3T6cOnAPsi+EF3VuGZFg==",
       "requires": {
         "for-each-property": "0.0.4",
         "for-each-property-deep": "0.0.3",
-        "inspect-function": "^0.3.1"
+        "inspect-function": "^0.4.0"
       },
       "dependencies": {
+        "cliss": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/cliss/-/cliss-0.0.2.tgz",
+          "integrity": "sha512-6rj9pgdukjT994Md13JCUAgTk91abAKrygL9sAvmHY4F6AKMOV8ccGaxhUUfcBuyg3sundWnn3JE0Mc9W6ZYqw==",
+          "requires": {
+            "command-line-usage": "^4.0.1",
+            "deepmerge": "^2.0.0",
+            "get-stdin": "^5.0.1",
+            "inspect-parameters-declaration": "0.0.9",
+            "object-to-arguments": "0.0.8",
+            "pipe-functions": "^1.3.0",
+            "strip-ansi": "^4.0.0",
+            "yargs-parser": "^7.0.0"
+          },
+          "dependencies": {
+            "inspect-function": {
+              "version": "0.2.2",
+              "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.2.2.tgz",
+              "integrity": "sha1-hdoMUli8TDMK4yg7Z0fgdZ2QpjU=",
+              "requires": {
+                "split-skip": "0.0.1",
+                "unpack-string": "0.0.2"
+              },
+              "dependencies": {
+                "split-skip": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.1.tgz",
+                  "integrity": "sha1-gK2ONumOV2RUzDtmfB3SXYZejwA="
+                }
+              }
+            },
+            "inspect-parameters-declaration": {
+              "version": "0.0.9",
+              "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.9.tgz",
+              "integrity": "sha512-c3jrKKA1rwwrsjdGMAo2hFWV0vNe3/RKHxpE/OBt41LP3ynOVI1qmgxpZYK5SQu3jtWCyaho8L7AZzCjJ4mEUw==",
+              "requires": {
+                "magicli": "0.0.5",
+                "split-skip": "0.0.2",
+                "stringify-parameters": "0.0.4",
+                "unpack-string": "0.0.2"
+              }
+            },
+            "magicli": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+              "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+              "requires": {
+                "commander": "^2.9.0",
+                "get-stdin": "^5.0.1",
+                "inspect-function": "^0.2.1",
+                "pipe-functions": "^1.2.0"
+              }
+            },
+            "split-skip": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.2.tgz",
+              "integrity": "sha1-2J2Iu9L3Pka1FYqjcKVhIk6A1GE="
+            },
+            "stringify-parameters": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",
+              "integrity": "sha512-H3L90ERn5UPtkpO8eugnKcLgpIVlvTyUTrcLGm607AV5JDH6z0GymtNLr3gjGlP6I6NB/mxNX9QpY6jEQGLPdQ==",
+              "requires": {
+                "magicli": "0.0.5",
+                "unpack-string": "0.0.2"
+              }
+            }
+          }
+        },
         "inspect-function": {
-          "version": "0.3.4",
-          "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.3.4.tgz",
-          "integrity": "sha512-s0RsbJqK/sNZ+U1mykGoTickog3ea1A9Qk4mXniogOBu4PgkkZ56elScO7QC/r8D94lhGmJ2NyDI1ipOA/uq/g==",
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.4.0.tgz",
+          "integrity": "sha512-flt3YG6fiyZKLAF607DI+YM1wmPk4OFmNyzwADeAnjR42t/TxTy/wfA8s1vwyvxOYEG0Da2/uKClGhcfaNZdkw==",
           "requires": {
             "inspect-parameters-declaration": "0.0.8",
             "magicli": "0.0.8",
             "split-skip": "0.0.1",
-            "stringify-parameters": "0.0.4",
+            "stringify-parameters": "0.0.7",
             "unpack-string": "0.0.2"
           }
         },
@@ -420,6 +912,146 @@
               "version": "0.0.2",
               "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.2.tgz",
               "integrity": "sha1-2J2Iu9L3Pka1FYqjcKVhIk6A1GE="
+            },
+            "stringify-parameters": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",
+              "integrity": "sha512-H3L90ERn5UPtkpO8eugnKcLgpIVlvTyUTrcLGm607AV5JDH6z0GymtNLr3gjGlP6I6NB/mxNX9QpY6jEQGLPdQ==",
+              "requires": {
+                "magicli": "0.0.5",
+                "unpack-string": "0.0.2"
+              }
+            }
+          }
+        },
+        "inspect-property": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/inspect-property/-/inspect-property-0.0.6.tgz",
+          "integrity": "sha512-LgjHkRl9W6bj2n+kWrAOgvCYPTYt+LanE4rtd/vKNq6yEb+SvVV7UTLzoSPpDX6/U1cAz7VfqPr+lPAIz7wHaQ==",
+          "requires": {
+            "for-each-property": "0.0.4",
+            "for-each-property-deep": "0.0.3",
+            "inspect-function": "^0.3.1"
+          },
+          "dependencies": {
+            "inspect-function": {
+              "version": "0.3.4",
+              "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.3.4.tgz",
+              "integrity": "sha512-s0RsbJqK/sNZ+U1mykGoTickog3ea1A9Qk4mXniogOBu4PgkkZ56elScO7QC/r8D94lhGmJ2NyDI1ipOA/uq/g==",
+              "requires": {
+                "inspect-parameters-declaration": "0.0.8",
+                "magicli": "0.0.8",
+                "split-skip": "0.0.1",
+                "stringify-parameters": "0.0.4",
+                "unpack-string": "0.0.2"
+              }
+            },
+            "stringify-parameters": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",
+              "integrity": "sha512-H3L90ERn5UPtkpO8eugnKcLgpIVlvTyUTrcLGm607AV5JDH6z0GymtNLr3gjGlP6I6NB/mxNX9QpY6jEQGLPdQ==",
+              "requires": {
+                "magicli": "0.0.5",
+                "unpack-string": "0.0.2"
+              },
+              "dependencies": {
+                "inspect-function": {
+                  "version": "0.2.2",
+                  "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.2.2.tgz",
+                  "integrity": "sha1-hdoMUli8TDMK4yg7Z0fgdZ2QpjU=",
+                  "requires": {
+                    "split-skip": "0.0.1",
+                    "unpack-string": "0.0.2"
+                  }
+                },
+                "magicli": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+                  "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+                  "requires": {
+                    "commander": "^2.9.0",
+                    "get-stdin": "^5.0.1",
+                    "inspect-function": "^0.2.1",
+                    "pipe-functions": "^1.2.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "magicli": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.8.tgz",
+          "integrity": "sha512-x/eBenweAHF+DsYy172sK4doRxZl0yrJnfxhLJiN7H6hPM3Ya0PfI6uBZshZ3ScFFSQD7HXgBqMdbnXKEZsO1g==",
+          "requires": {
+            "cliss": "0.0.2",
+            "find-up": "^2.1.0",
+            "for-each-property": "0.0.4"
+          }
+        },
+        "object-to-arguments": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/object-to-arguments/-/object-to-arguments-0.0.8.tgz",
+          "integrity": "sha512-BfWfuAwuhdH1bhMG5EG90WE/eckkBhBvnke8eSEkCDXoLE9Jk5JwYGTbCx1ehGwV48HvBkn62VukPBdlMUOY9w==",
+          "requires": {
+            "inspect-parameters-declaration": "0.0.10",
+            "magicli": "0.0.5",
+            "split-skip": "0.0.2",
+            "stringify-parameters": "0.0.4",
+            "unpack-string": "0.0.2"
+          },
+          "dependencies": {
+            "inspect-function": {
+              "version": "0.2.2",
+              "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.2.2.tgz",
+              "integrity": "sha1-hdoMUli8TDMK4yg7Z0fgdZ2QpjU=",
+              "requires": {
+                "split-skip": "0.0.1",
+                "unpack-string": "0.0.2"
+              },
+              "dependencies": {
+                "split-skip": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.1.tgz",
+                  "integrity": "sha1-gK2ONumOV2RUzDtmfB3SXYZejwA="
+                }
+              }
+            },
+            "inspect-parameters-declaration": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.10.tgz",
+              "integrity": "sha512-L8/Bvt9iDXQTZ63xY5/MAyvzz+FagR/qGh1kIXvUpsno3AAE0Z95d6QO51zrcMGaEGpwh/57idfMxTxbvRmytg==",
+              "requires": {
+                "magicli": "0.0.5",
+                "split-skip": "0.0.2",
+                "stringify-parameters": "0.0.4",
+                "unpack-string": "0.0.2"
+              }
+            },
+            "magicli": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+              "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+              "requires": {
+                "commander": "^2.9.0",
+                "get-stdin": "^5.0.1",
+                "inspect-function": "^0.2.1",
+                "pipe-functions": "^1.2.0"
+              }
+            },
+            "split-skip": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.2.tgz",
+              "integrity": "sha1-2J2Iu9L3Pka1FYqjcKVhIk6A1GE="
+            },
+            "stringify-parameters": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",
+              "integrity": "sha512-H3L90ERn5UPtkpO8eugnKcLgpIVlvTyUTrcLGm607AV5JDH6z0GymtNLr3gjGlP6I6NB/mxNX9QpY6jEQGLPdQ==",
+              "requires": {
+                "magicli": "0.0.5",
+                "unpack-string": "0.0.2"
+              }
             }
           }
         },
@@ -435,6 +1067,71 @@
       "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
       "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        }
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -449,15 +1146,24 @@
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
     },
-    "magicli": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.8.tgz",
-      "integrity": "sha512-x/eBenweAHF+DsYy172sK4doRxZl0yrJnfxhLJiN7H6hPM3Ya0PfI6uBZshZ3ScFFSQD7HXgBqMdbnXKEZsO1g==",
+    "log-symbols": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "dev": true,
       "requires": {
-        "cliss": "0.0.2",
+        "chalk": "^4.0.0"
+      }
+    },
+    "magicli": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.2.1.tgz",
+      "integrity": "sha512-6sR0xpSDW2Wd5dxu4TLKuI0qcQbU2y+IP5o2hTk/h/MT3PWeiAt0Wa+IqfmDF1vVgbU0e1cP8TM+kbIxOK2o7w==",
+      "requires": {
+        "cliss": "0.0.8",
         "find-up": "^2.1.0",
         "for-each-property": "0.0.4",
-        "inspect-property": "0.0.6"
+        "inspect-property": "0.0.7"
       }
     },
     "minimatch": {
@@ -469,52 +1175,100 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
-    },
     "mocha": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
+      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
       "dev": true,
       "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "commander": "2.15.1",
-        "debug": "3.1.0",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
+        "chokidar": "3.5.1",
+        "debug": "4.3.1",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.6",
         "growl": "1.10.5",
-        "he": "1.1.1",
+        "he": "1.2.0",
+        "js-yaml": "4.0.0",
+        "log-symbols": "4.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "supports-color": "5.4.0"
+        "ms": "2.1.3",
+        "nanoid": "3.1.20",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.1.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
           "dev": true
         }
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
       "dev": true
     },
     "node.extend": {
@@ -526,29 +1280,24 @@
         "is": "^3.2.1"
       }
     },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
     "object-to-arguments": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/object-to-arguments/-/object-to-arguments-0.0.8.tgz",
-      "integrity": "sha512-BfWfuAwuhdH1bhMG5EG90WE/eckkBhBvnke8eSEkCDXoLE9Jk5JwYGTbCx1ehGwV48HvBkn62VukPBdlMUOY9w==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-to-arguments/-/object-to-arguments-0.1.0.tgz",
+      "integrity": "sha512-To3khIQt4DeuRqud1hW85Ppq4aIPkVlDXebk/reGUq9+Xz3haU4DEixmqO5+TIV6sghqQ5D4aTunRQkWHQJCaA==",
       "requires": {
-        "inspect-parameters-declaration": "0.0.10",
+        "inspect-parameters-declaration": "0.1.0",
         "magicli": "0.0.5",
         "split-skip": "0.0.2",
-        "stringify-parameters": "0.0.4",
+        "stringify-parameters": "0.0.7",
         "unpack-string": "0.0.2"
       },
       "dependencies": {
-        "inspect-parameters-declaration": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.10.tgz",
-          "integrity": "sha512-L8/Bvt9iDXQTZ63xY5/MAyvzz+FagR/qGh1kIXvUpsno3AAE0Z95d6QO51zrcMGaEGpwh/57idfMxTxbvRmytg==",
-          "requires": {
-            "magicli": "0.0.5",
-            "split-skip": "0.0.2",
-            "stringify-parameters": "0.0.4",
-            "unpack-string": "0.0.2"
-          }
-        },
         "magicli": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
@@ -603,6 +1352,18 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "dev": true
+    },
     "pipe-functions": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/pipe-functions/-/pipe-functions-1.3.0.tgz",
@@ -610,13 +1371,52 @@
     },
     "printj": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
       "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "readdirp": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
     },
     "reduce-flatten": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
       "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "split-skip": {
       "version": "0.0.2",
@@ -629,31 +1429,251 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "ssf": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.10.2.tgz",
-      "integrity": "sha512-rDhAPm9WyIsY8eZEKyE8Qsotb3j/wBdvMWBUsOhJdfhKGLfQidRjiBUV0y/MkyCLiXQ38FG6LWW/VYUtqlIDZQ==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
       "requires": {
         "frac": "~1.1.2"
       }
     },
-    "stringify-parameters": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",
-      "integrity": "sha512-H3L90ERn5UPtkpO8eugnKcLgpIVlvTyUTrcLGm607AV5JDH6z0GymtNLr3gjGlP6I6NB/mxNX9QpY6jEQGLPdQ==",
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "requires": {
-        "magicli": "0.0.5",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "stringify-parameters": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.7.tgz",
+      "integrity": "sha512-kBKDav/PD7NKhgCFyD238Ba1Mt2OaBHTy5WheSUSIVuSsW7npRAyVGAiBA9HXhcp8vK2QHnNrpbkIAmebe2ppQ==",
+      "requires": {
+        "magicli": "0.0.8",
         "unpack-string": "0.0.2"
       },
       "dependencies": {
-        "magicli": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
-          "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+        "cliss": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/cliss/-/cliss-0.0.2.tgz",
+          "integrity": "sha512-6rj9pgdukjT994Md13JCUAgTk91abAKrygL9sAvmHY4F6AKMOV8ccGaxhUUfcBuyg3sundWnn3JE0Mc9W6ZYqw==",
           "requires": {
-            "commander": "^2.9.0",
+            "command-line-usage": "^4.0.1",
+            "deepmerge": "^2.0.0",
             "get-stdin": "^5.0.1",
-            "inspect-function": "^0.2.1",
-            "pipe-functions": "^1.2.0"
+            "inspect-parameters-declaration": "0.0.9",
+            "object-to-arguments": "0.0.8",
+            "pipe-functions": "^1.3.0",
+            "strip-ansi": "^4.0.0",
+            "yargs-parser": "^7.0.0"
+          }
+        },
+        "inspect-parameters-declaration": {
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.9.tgz",
+          "integrity": "sha512-c3jrKKA1rwwrsjdGMAo2hFWV0vNe3/RKHxpE/OBt41LP3ynOVI1qmgxpZYK5SQu3jtWCyaho8L7AZzCjJ4mEUw==",
+          "requires": {
+            "magicli": "0.0.5",
+            "split-skip": "0.0.2",
+            "unpack-string": "0.0.2"
+          },
+          "dependencies": {
+            "magicli": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+              "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+              "requires": {
+                "commander": "^2.9.0",
+                "get-stdin": "^5.0.1",
+                "inspect-function": "^0.2.1",
+                "pipe-functions": "^1.2.0"
+              }
+            }
+          }
+        },
+        "inspect-property": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/inspect-property/-/inspect-property-0.0.6.tgz",
+          "integrity": "sha512-LgjHkRl9W6bj2n+kWrAOgvCYPTYt+LanE4rtd/vKNq6yEb+SvVV7UTLzoSPpDX6/U1cAz7VfqPr+lPAIz7wHaQ==",
+          "requires": {
+            "for-each-property": "0.0.4",
+            "for-each-property-deep": "0.0.3",
+            "inspect-function": "^0.3.1"
+          },
+          "dependencies": {
+            "inspect-function": {
+              "version": "0.3.4",
+              "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.3.4.tgz",
+              "integrity": "sha512-s0RsbJqK/sNZ+U1mykGoTickog3ea1A9Qk4mXniogOBu4PgkkZ56elScO7QC/r8D94lhGmJ2NyDI1ipOA/uq/g==",
+              "requires": {
+                "inspect-parameters-declaration": "0.0.8",
+                "magicli": "0.0.8",
+                "split-skip": "0.0.1",
+                "stringify-parameters": "0.0.4",
+                "unpack-string": "0.0.2"
+              }
+            },
+            "inspect-parameters-declaration": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.8.tgz",
+              "integrity": "sha512-W4QzN1LgFmasKOM+NoLlDd2OAZM3enNZlVUOXoGQKmYBDFgxoPDOyebF55ALaf8avyM9TavNwibXxg347RrzCg==",
+              "requires": {
+                "magicli": "0.0.5",
+                "split-skip": "0.0.2",
+                "stringify-parameters": "0.0.4",
+                "unpack-string": "0.0.2"
+              },
+              "dependencies": {
+                "inspect-function": {
+                  "version": "0.2.2",
+                  "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.2.2.tgz",
+                  "integrity": "sha1-hdoMUli8TDMK4yg7Z0fgdZ2QpjU=",
+                  "requires": {
+                    "split-skip": "0.0.1",
+                    "unpack-string": "0.0.2"
+                  },
+                  "dependencies": {
+                    "split-skip": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.1.tgz",
+                      "integrity": "sha1-gK2ONumOV2RUzDtmfB3SXYZejwA="
+                    }
+                  }
+                },
+                "magicli": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+                  "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+                  "requires": {
+                    "commander": "^2.9.0",
+                    "get-stdin": "^5.0.1",
+                    "inspect-function": "^0.2.1",
+                    "pipe-functions": "^1.2.0"
+                  }
+                },
+                "split-skip": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.2.tgz",
+                  "integrity": "sha1-2J2Iu9L3Pka1FYqjcKVhIk6A1GE="
+                }
+              }
+            },
+            "split-skip": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.1.tgz",
+              "integrity": "sha1-gK2ONumOV2RUzDtmfB3SXYZejwA="
+            },
+            "stringify-parameters": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",
+              "integrity": "sha512-H3L90ERn5UPtkpO8eugnKcLgpIVlvTyUTrcLGm607AV5JDH6z0GymtNLr3gjGlP6I6NB/mxNX9QpY6jEQGLPdQ==",
+              "requires": {
+                "magicli": "0.0.5",
+                "unpack-string": "0.0.2"
+              },
+              "dependencies": {
+                "inspect-function": {
+                  "version": "0.2.2",
+                  "resolved": "https://registry.npmjs.org/inspect-function/-/inspect-function-0.2.2.tgz",
+                  "integrity": "sha1-hdoMUli8TDMK4yg7Z0fgdZ2QpjU=",
+                  "requires": {
+                    "split-skip": "0.0.1",
+                    "unpack-string": "0.0.2"
+                  }
+                },
+                "magicli": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+                  "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+                  "requires": {
+                    "commander": "^2.9.0",
+                    "get-stdin": "^5.0.1",
+                    "inspect-function": "^0.2.1",
+                    "pipe-functions": "^1.2.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "magicli": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.8.tgz",
+          "integrity": "sha512-x/eBenweAHF+DsYy172sK4doRxZl0yrJnfxhLJiN7H6hPM3Ya0PfI6uBZshZ3ScFFSQD7HXgBqMdbnXKEZsO1g==",
+          "requires": {
+            "cliss": "0.0.2",
+            "find-up": "^2.1.0",
+            "for-each-property": "0.0.4",
+            "inspect-property": "0.0.6"
+          }
+        },
+        "object-to-arguments": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/object-to-arguments/-/object-to-arguments-0.0.8.tgz",
+          "integrity": "sha512-BfWfuAwuhdH1bhMG5EG90WE/eckkBhBvnke8eSEkCDXoLE9Jk5JwYGTbCx1ehGwV48HvBkn62VukPBdlMUOY9w==",
+          "requires": {
+            "inspect-parameters-declaration": "0.0.10",
+            "magicli": "0.0.5",
+            "split-skip": "0.0.2",
+            "stringify-parameters": "0.0.4",
+            "unpack-string": "0.0.2"
+          },
+          "dependencies": {
+            "inspect-parameters-declaration": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.10.tgz",
+              "integrity": "sha512-L8/Bvt9iDXQTZ63xY5/MAyvzz+FagR/qGh1kIXvUpsno3AAE0Z95d6QO51zrcMGaEGpwh/57idfMxTxbvRmytg==",
+              "requires": {
+                "magicli": "0.0.5",
+                "split-skip": "0.0.2",
+                "stringify-parameters": "0.0.4",
+                "unpack-string": "0.0.2"
+              }
+            },
+            "magicli": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+              "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+              "requires": {
+                "commander": "^2.9.0",
+                "get-stdin": "^5.0.1",
+                "inspect-function": "^0.2.1",
+                "pipe-functions": "^1.2.0"
+              }
+            },
+            "stringify-parameters": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",
+              "integrity": "sha512-H3L90ERn5UPtkpO8eugnKcLgpIVlvTyUTrcLGm607AV5JDH6z0GymtNLr3gjGlP6I6NB/mxNX9QpY6jEQGLPdQ==",
+              "requires": {
+                "magicli": "0.0.5",
+                "unpack-string": "0.0.2"
+              }
+            }
+          }
+        },
+        "stringify-parameters": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",
+          "integrity": "sha512-H3L90ERn5UPtkpO8eugnKcLgpIVlvTyUTrcLGm607AV5JDH6z0GymtNLr3gjGlP6I6NB/mxNX9QpY6jEQGLPdQ==",
+          "requires": {
+            "magicli": "0.0.5",
+            "unpack-string": "0.0.2"
+          },
+          "dependencies": {
+            "magicli": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
+              "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
+              "requires": {
+                "commander": "^2.9.0",
+                "get-stdin": "^5.0.1",
+                "inspect-function": "^0.2.1",
+                "pipe-functions": "^1.2.0"
+              }
+            }
           }
         }
       }
@@ -666,19 +1686,25 @@
         "ansi-regex": "^3.0.0"
       }
     },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
     "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       }
     },
     "table-layout": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.4.tgz",
-      "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz",
+      "integrity": "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==",
       "requires": {
         "array-back": "^2.0.0",
         "deep-extend": "~0.6.0",
@@ -687,10 +1713,19 @@
         "wordwrapjs": "^3.0.0"
       }
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "typical": {
@@ -703,6 +1738,34 @@
       "resolved": "https://registry.npmjs.org/unpack-string/-/unpack-string-0.0.2.tgz",
       "integrity": "sha1-MC7PCCOLATm9Q0pNf9Z83zPKJ10="
     },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="
+    },
+    "word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="
+    },
     "wordwrapjs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
@@ -712,6 +1775,57 @@
         "typical": "^2.6.1"
       }
     },
+    "workerpool": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -719,23 +1833,87 @@
       "dev": true
     },
     "xlsx": {
-      "version": "0.12.13",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.12.13.tgz",
-      "integrity": "sha512-9/2H4PLphmG8sDvI3mfWb6JIFqbvK8IRGhgS55Pw5F+fmKPuzdv4OW9RFjrH5PiTKeqB/883Z8o+jW3JrDahmw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.17.0.tgz",
+      "integrity": "sha512-bZ36FSACiAyjoldey1+7it50PMlDp1pcAJrZKcVZHzKd8BC/z6TQ/QAN8onuqcepifqSznR6uKnjPhaGt6ig9A==",
       "requires": {
         "adler-32": "~1.2.0",
-        "cfb": "~1.0.7",
-        "codepage": "~1.13.0",
-        "commander": "~2.15.1",
+        "cfb": "^1.1.4",
+        "codepage": "~1.14.0",
+        "commander": "~2.17.1",
         "crc-32": "~1.2.0",
         "exit-on-epipe": "~1.0.1",
-        "ssf": "~0.10.2"
+        "fflate": "^0.3.8",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
       },
       "dependencies": {
         "commander": {
-          "version": "2.15.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+        }
+      }
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.7",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+          "dev": true
         }
       }
     },
@@ -746,6 +1924,32 @@
       "requires": {
         "camelcase": "^4.1.0"
       }
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        }
+      }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "test": "mocha ./tests -b"
   },
   "dependencies": {
-    "argparse": "^1.0.2",
-    "magicli": "0.0.8",
+    "argparse": "^1.0.9",
+    "magicli": "0.2.1",
     "node.extend": "^2.0.2",
-    "xlsx": "^0.12.1"
+    "xlsx": "^0.17.0"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "mocha": "^5.2.0"
+    "chai": "^4.3.4",
+    "mocha": "^8.4.0"
   }
 }


### PR DESCRIPTION
The dependencies of this library are quite old and have a few reported vulnerabilities.

This PR updates them all to latest stable versions.

I chose not to update "argparse" to 2.x because it would require a change to the usage of the library.