### PR TITLE
Auto use w when v is not the same in value

### DIFF
--- a/lib/convert-excel-to-json.js
+++ b/lib/convert-excel-to-json.js
@@ -19,7 +19,7 @@ const excelToJson = (function() {
             return null;
         }
         const rawValue = (sheetCell.t === 'n' || sheetCell.t === 'd') ? sheetCell.v : (sheetCell.w && sheetCell.w.trim && sheetCell.w.trim()) || sheetCell.w;
-        if (typeof sheetCell.v === 'number' && parseInt(sheetCell.w.trim()) !== sheetCell.v) {
+        if (typeof sheetCell.v === 'number' && !isNaN(Number(sheetCell.w.trim())) && parseInt(sheetCell.w.trim()) !== sheetCell.v) {
             return Number(sheetCell.w.trim())
         }
         return rawValue

--- a/lib/convert-excel-to-json.js
+++ b/lib/convert-excel-to-json.js
@@ -18,7 +18,11 @@ const excelToJson = (function() {
         if (sheetCell.t === 'z' && _config.sheetStubs) {
             return null;
         }
-        return (sheetCell.t === 'n' || sheetCell.t === 'd') ? sheetCell.v : (sheetCell.w && sheetCell.w.trim && sheetCell.w.trim()) || sheetCell.w;
+        const rawValue = (sheetCell.t === 'n' || sheetCell.t === 'd') ? sheetCell.v : (sheetCell.w && sheetCell.w.trim && sheetCell.w.trim()) || sheetCell.w;
+        if (typeof sheetCell.v === 'number' && parseInt(sheetCell.w.trim()) !== sheetCell.v) {
+            return Number(sheetCell.w.trim())
+        }
+        return rawValue
     };
 
     const parseSheet = (sheetData, workbook) => {


### PR DESCRIPTION
Alternative solution without extra configuration Related to #40

`w: 77,666 ===> 77,666`
`v: 101.234, w: 101 ===> 101`

Related issues address are: https://github.com/DiegoZoracKy/convert-excel-to-json/issues/4 and https://github.com/DiegoZoracKy/convert-excel-to-json/issues/31.